### PR TITLE
Add in limited support for static allocation

### DIFF
--- a/c++/Source/cevent_groups.cpp
+++ b/c++/Source/cevent_groups.cpp
@@ -43,6 +43,7 @@
 
 using namespace cpp_freertos;
 
+#if( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 EventGroup::EventGroup()
 {
@@ -57,6 +58,7 @@ EventGroup::EventGroup()
     }
 
 }
+#endif // ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 
 #if( configSUPPORT_STATIC_ALLOCATION == 1 )

--- a/c++/Source/cmutex.cpp
+++ b/c++/Source/cmutex.cpp
@@ -59,7 +59,7 @@ Mutex::~Mutex()
 
 MutexStandard::MutexStandard()
 {
-    handle = xSemaphoreCreateMutex();
+    handle = xSemaphoreCreateMutexStatic(&MutexBuffer);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/cqueue.cpp
+++ b/c++/Source/cqueue.cpp
@@ -46,9 +46,9 @@
 using namespace cpp_freertos;
 
 
-Queue::Queue(UBaseType_t maxItems, UBaseType_t itemSize)
+Queue::Queue(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t *buffer)
 {
-    handle = xQueueCreate(maxItems, itemSize);
+    handle = xQueueCreateStatic(maxItems, itemSize, buffer, &queue_buffer_);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -170,8 +170,8 @@ UBaseType_t Queue::NumSpacesLeft()
 }
 
 
-Deque::Deque(UBaseType_t maxItems, UBaseType_t itemSize)
-    : Queue(maxItems, itemSize)
+Deque::Deque(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t * buffer)
+    : Queue(maxItems, itemSize, buffer)
 {
 }
 
@@ -196,8 +196,8 @@ bool Deque::EnqueueToFrontFromISR(void *item, BaseType_t *pxHigherPriorityTaskWo
 }
 
 
-BinaryQueue::BinaryQueue(UBaseType_t itemSize)
-    : Queue(1, itemSize)
+BinaryQueue::BinaryQueue(UBaseType_t itemSize, uint8_t * buffer)
+    : Queue(1, itemSize, buffer)
 {
 }
 

--- a/c++/Source/cread_write_lock.cpp
+++ b/c++/Source/cread_write_lock.cpp
@@ -45,6 +45,7 @@
 
 using namespace cpp_freertos;
 
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 ReadWriteLock::ReadWriteLock()
     : ReadCount(0)
@@ -227,3 +228,5 @@ void ReadWriteLockPreferWriter::WriterUnlock()
 
     xSemaphoreGive(WriteLock);
 }
+
+#endif // ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )

--- a/c++/Source/csemaphore.cpp
+++ b/c++/Source/csemaphore.cpp
@@ -99,7 +99,7 @@ Semaphore::~Semaphore()
 
 BinarySemaphore::BinarySemaphore(bool set)
 {
-    handle = xSemaphoreCreateBinary();
+    handle = xSemaphoreCreateBinaryStatic(&semaphore_buffer_);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -114,6 +114,7 @@ BinarySemaphore::BinarySemaphore(bool set)
     }
 }
 
+#if ( configUSE_COUNTING_SEMAPHORES == 1 )
 
 CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCount)
 {
@@ -133,7 +134,7 @@ CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCo
 #endif
     }
 
-    handle = xSemaphoreCreateCounting(maxCount, initialCount);
+    handle = xSemaphoreCreateCountingStatic(maxCount, initialCount, &semaphore_buffer_);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -144,4 +145,4 @@ CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCo
     }
 }
 
-
+#endif  // ( configUSE_COUNTING_SEMAPHORES == 1 )

--- a/c++/Source/ctasklet.cpp
+++ b/c++/Source/ctasklet.cpp
@@ -45,6 +45,7 @@
 
 using namespace cpp_freertos;
 
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 Tasklet::Tasklet()
 {
@@ -129,3 +130,4 @@ bool Tasklet::ScheduleFromISR(  uint32_t parameter,
     }
 }
 
+#endif // ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )

--- a/c++/Source/ctimer.cpp
+++ b/c++/Source/ctimer.cpp
@@ -51,11 +51,12 @@ Timer::Timer(   const char * const TimerName,
                 bool Periodic
                 )
 {
-    handle = xTimerCreate(  TimerName,
+    handle = xTimerCreateStatic(  TimerName,
                             PeriodInTicks,
                             Periodic ? pdTRUE : pdFALSE,
                             this,
-                            TimerCallbackFunctionAdapter);
+                            TimerCallbackFunctionAdapter,
+                            &timer_buffer_);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -71,11 +72,12 @@ Timer::Timer(   TickType_t PeriodInTicks,
                 bool Periodic
                 )
 {
-    handle = xTimerCreate(  "Default",
+    handle = xTimerCreateStatic(  "Default",
                             PeriodInTicks,
                             Periodic ? pdTRUE : pdFALSE,
                             this,
-                            TimerCallbackFunctionAdapter);
+                            TimerCallbackFunctionAdapter,
+                            &timer_buffer_);
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/cworkqueue.cpp
+++ b/c++/Source/cworkqueue.cpp
@@ -45,6 +45,7 @@
 
 using namespace cpp_freertos;
 
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 WorkItem::WorkItem(bool freeAfterComplete)
     : FreeItemAfterCompleted(freeAfterComplete)
@@ -207,4 +208,4 @@ void WorkQueue::CWorkerThread::Run()
     ParentWorkQueue->ThreadComplete->Give();
 }
 
-
+#endif // ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )

--- a/c++/Source/include/mutex.hpp
+++ b/c++/Source/include/mutex.hpp
@@ -47,7 +47,7 @@
  *  C++ exceptions are used by default when constructors fail.
  *  If you do not want this behavior, define the following in your makefile
  *  or project. Note that in most / all cases when a constructor fails,
- *  it's a fatal error. In the cases when you've defined this, the new 
+ *  it's a fatal error. In the cases when you've defined this, the new
  *  default behavior will be to issue a configASSERT() instead.
  */
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -199,6 +199,9 @@ class MutexStandard : public Mutex {
          *           if it fails, did you call Lock() first?)
          */
         virtual bool Unlock();
+
+    private:
+        StaticSemaphore_t MutexBuffer;
 };
 
 

--- a/c++/Source/include/queue.hpp
+++ b/c++/Source/include/queue.hpp
@@ -47,7 +47,7 @@
  *  C++ exceptions are used by default when constructors fail.
  *  If you do not want this behavior, define the following in your makefile
  *  or project. Note that in most / all cases when a constructor fails,
- *  it's a fatal error. In the cases when you've defined this, the new 
+ *  it's a fatal error. In the cases when you've defined this, the new
  *  default behavior will be to issue a configASSERT() instead.
  */
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -131,7 +131,7 @@ class Queue {
          *  @param itemSize Size of an item in a queue.
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
-        Queue(UBaseType_t maxItems, UBaseType_t itemSize);
+        Queue(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t * buffer);
 
         /**
          *  Our destructor.
@@ -248,6 +248,10 @@ class Queue {
          *  FreeRTOS queue handle.
          */
         QueueHandle_t handle;
+
+    private:
+        StaticQueue_t queue_buffer_;
+
 };
 
 
@@ -276,7 +280,7 @@ class Deque : public Queue {
          *  @param itemSize Size of an item in a queue.
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
-        Deque(UBaseType_t maxItems, UBaseType_t itemSize);
+        Deque(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t * buffer);
 
         /**
          *  Add an item to the front of the queue. This will result in
@@ -328,7 +332,7 @@ class BinaryQueue : public Queue {
          *  @param itemSize Size of an item in a queue.
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
-        explicit BinaryQueue(UBaseType_t itemSize);
+        explicit BinaryQueue(UBaseType_t itemSize, uint8_t * buffer);
 
          /**
           *  Add an item to the queue.

--- a/c++/Source/include/semaphore.hpp
+++ b/c++/Source/include/semaphore.hpp
@@ -47,7 +47,7 @@
  *  C++ exceptions are used by default when constructors fail.
  *  If you do not want this behavior, define the following in your makefile
  *  or project. Note that in most / all cases when a constructor fails,
- *  it's a fatal error. In the cases when you've defined this, the new 
+ *  it's a fatal error. In the cases when you've defined this, the new
  *  default behavior will be to issue a configASSERT() instead.
  */
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -188,6 +188,8 @@ class Semaphore {
          *  directly created, this is a base class only.
          */
         Semaphore();
+
+        StaticSemaphore_t semaphore_buffer_;
 };
 
 
@@ -212,6 +214,7 @@ class BinarySemaphore : public Semaphore {
         explicit BinarySemaphore(bool set = false);
 };
 
+#if ( configUSE_COUNTING_SEMAPHORES == 1 )
 
 /**
  *  Wrapper class for Counting Semaphores.
@@ -236,6 +239,7 @@ class CountingSemaphore : public Semaphore {
         CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCount);
 };
 
+#endif  // ( configUSE_COUNTING_SEMAPHORES == 1 )
 
 }
 #endif

--- a/c++/Source/include/timer.hpp
+++ b/c++/Source/include/timer.hpp
@@ -48,7 +48,7 @@
  *  C++ exceptions are used by default when constructors fail.
  *  If you do not want this behavior, define the following in your makefile
  *  or project. Note that in most / all cases when a constructor fails,
- *  it's a fatal error. In the cases when you've defined this, the new 
+ *  it's a fatal error. In the cases when you've defined this, the new
  *  default behavior will be to issue a configASSERT() instead.
  */
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -280,6 +280,8 @@ class Timer {
          *  Reference to the underlying timer handle.
          */
         TimerHandle_t handle;
+
+        StaticTimer_t timer_buffer_;
 
         /**
          *  Adapter function that allows you to write a class


### PR DESCRIPTION
# Teamwork Ticket 🎫
- [ ] Link to the corresponding Teamwork ticket: [Teamwork Ticket: 
freeRTOS integration ](https://selectspace.teamwork.com/app/tasks/31944281)

# Design Notes 📋
- [ ] I have made some crude changes to support static allocation.  Dynamic allocation is no longer supported.

Commenting has not been uniformly updated.


# Testing ✅
- [ ] There is minimal testing:
  - no unit testing (none in the original code base either)
  - I have run a sample program consisting of tasks, queues, a timer and a semaphore on:
    -  the STM32H743 eval board  (<https://github.com/dhawthorne-selectronic/stm_play/blob/master/Core/Src/business.cpp>)
    - the f2838 eval board (<https://github.com/dhawthorne-selectronic/freertos-etl-play/blob/master/freertos_ex2_c28x_led_blinky/freertos_ex2_c28x_led_blinky.cpp>)

# Related PRs 🖇️
- [ ] Link any related pull requests, if applicable.





