### PR TITLE
 Issue of Hardfault due to Thread exit of WorkQueue.

### DIFF
--- a/c++/Source/cworkqueue.cpp
+++ b/c++/Source/cworkqueue.cpp
@@ -232,7 +232,7 @@ void WorkQueue::CWorkerThread::Run()
             //
             //  Exit the task loop.
             //
-            break;
+            continue;
         }
 
         //
@@ -254,4 +254,3 @@ void WorkQueue::CWorkerThread::Run()
     //
     ParentWorkQueue.ThreadComplete.Give();
 }
-

--- a/c++/Source/cworkqueue.cpp
+++ b/c++/Source/cworkqueue.cpp
@@ -143,18 +143,6 @@ WorkQueue::~WorkQueue()
     //  Note that we cannot flush the queue. If there are items 
     //  in the queue maked freeAfterComplete, we would leak the 
     //  memory. 
-    //
-
-    //
-    //  Send a message that it's time to cleanup.
-    //
-    WorkItem *work = NULL;
-    WorkItemQueue.Enqueue(&work);
-
-    //
-    //  Wait until the thread has run enough to signal that it's done.
-    //
-    ThreadComplete.Take();
 }
 
 #endif


### PR DESCRIPTION
### **This PR address the issue of Hardfault due to Thread exit of WorkQueue.**
TICKET: [SW-307](https://github.com/Selectronic-AU/freertos-addons/pull/7)

Exiting the thread via break causes the task function to return, which triggers:

- prvTaskExitError() (see port.c line 228-249) - FreeRTOS task functions must never return
- The Idle task then attempts cleanup via prvCheckTasksWaitingTermination() (see tasks.c line 6074-6145) which tries to free the TCB while it may still be scheduled or in use, it results in hardfault due to race condition in resource cleanup.

In C++, the situation is more complex than plain C:

- The task is owned by a C++ object (cpp_freertos::Thread wrapper)
- Task deletion (vTaskDelete) and object destruction (~Thread) are separate events
- The ~Thread() destructor calls vTaskDelete(handle) (see cthread.cpp line 326-362) If the task returns before destruction, vTaskDelete() may operate on an invalid/zombie task.
- Even calling vTaskDelete(NULL) from within Run() causes the task to be deleted while the destructor still holds a reference to it, leading to double-free or use-after-free.
- Therefore, the safest approach for a C++ wrapper task is to keep the thread alive but allowing the destructor to properly clean up when the object is destroyed.

[SW-307]: https://selectronic-au.atlassian.net/browse/SW-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ